### PR TITLE
[*] Updated the version to 0.16.0-rc.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lex"
-version = "0.15.0"
+version = "0.16.0-rc.1"
 description = "This library aids in parsing programming languages."
 readme = "README.md"
 repository = "https://github.com/nikdeapen/lex"

--- a/README.md
+++ b/README.md
@@ -6,27 +6,37 @@
 
 This library aids in parsing programming languages.
 
-    lex = "0.15.0"
+    lex = "0.16.0-rc.1"
 
 There are no dependencies.
 
 ## Lexer
 
-The lexer converts source text into a sequence of tokens using ordered rules. Tokens are generic
-over a user-defined `TokenKind` enum. The lexer is error-free — all input is tokenizable.
+The `lexer!` macro defines a token kind enum, implements the `TokenKind` trait, and generates a
+lexer constructor — all in one declaration. Rules are matched in declaration order.
 
 ```rust
-use lex::lexer::matchers::{ident, whitespace};
-use lex::lexer::{Lexer, Token, TokenKind};
-use lex::literal;
+use lex::lexer::matchers::{digits, ident, whitespace};
+use lex::{keyword, lexer, line_comment, literal};
 
-let lexer: Lexer<Kind> = Lexer::default()
-.with_rule(Kind::Whitespace, whitespace)
-.with_rule(Kind::Ident, ident)
-.with_rule(Kind::Semi, literal!(";"));
+lexer! {
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    pub enum Kind {
+        LineComment: line_comment!("//"),
+        Whitespace: whitespace,
+        Import: keyword!("import"),
+        Ident: ident,
+        Integer: digits,
+        LBrace: literal!("{"),
+        RBrace: literal!("}"),
+        Semi: literal!(";"),
+    }
+}
 
-let tokens: Vec<Token<Kind>> = lexer.lex("let x;");
+let tokens = Kind::lexer().lex("import foo;");
 ```
+
+`Unrecognized` and `EndOfFile` variants are added automatically.
 
 ## Parser
 
@@ -37,9 +47,9 @@ multi-error recovery, and leading comment extraction.
 use lex::parser::Parser;
 
 let mut parser: Parser<Kind> = Parser::new(source, tokens)
-.with_skip(Kind::Whitespace);
+    .with_skip(Kind::Whitespace);
 
-let token: Token<Kind> = parser.expect(Kind::Ident)?;
+let token = parser.expect(Kind::Ident)?;
 ```
 
 ## Built-in Matchers
@@ -48,4 +58,5 @@ let token: Token<Kind> = parser.expect(Kind::Ident)?;
 - `digits` — `[0-9]+`
 - `whitespace` — ASCII whitespace
 - `literal!("...")` — exact string match
+- `keyword!("...")` — exact string match with word boundary
 - `line_comment!("//")` — line comment with delimiter

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -1,7 +1,7 @@
 use crate::lexer::{Rule, Span, Token, TokenKind};
 
 /// A lexer. Converts source text into a sequence of tokens using ordered rules.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Lexer<K> {
     rules: Vec<Rule<K>>,
 }
@@ -23,6 +23,7 @@ impl<K> Lexer<K> {
     }
 
     /// Adds a rule to the lexer. (builder pattern)
+    #[must_use]
     pub fn with_rule(mut self, kind: K, matcher: fn(&str) -> Option<usize>) -> Self {
         self.add_rule(kind, matcher);
         self
@@ -50,7 +51,7 @@ impl<K: Copy + TokenKind> Lexer<K> {
         }
 
         let eof_span: Span = Span::new(pos as u32, 0);
-        tokens.push(Token::new(K::eof(), eof_span));
+        tokens.push(Token::new(K::end_of_file(), eof_span));
         tokens
     }
 
@@ -64,67 +65,32 @@ impl<K: Copy + TokenKind> Lexer<K> {
             }
         }
         let c: char = remaining.chars().next().unwrap();
-        (K::unknown(), c.len_utf8())
+        (K::unrecognized(), c.len_utf8())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::lexer::matchers::{digits, ident, whitespace};
-    use crate::lexer::{Lexer, Span, Token, TokenKind};
+    use crate::lexer::{Lexer, Span, Token};
     use crate::literal;
 
-    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-    enum Kind {
-        Whitespace,
-        Ident,
-        Int,
-        LBrace,
-        RBrace,
-        Semi,
-        Eq,
-        Unknown,
-        Eof,
-    }
-
-    impl TokenKind for Kind {
-        fn unknown() -> Self {
-            Kind::Unknown
+    crate::lexer! {
+        #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+        enum Kind {
+            Whitespace: whitespace,
+            Ident: ident,
+            Int: digits,
+            LBrace: literal!("{"),
+            RBrace: literal!("}"),
+            Semi: literal!(";"),
+            Eq: literal!("="),
         }
-
-        fn eof() -> Self {
-            Kind::Eof
-        }
-
-        fn label(&self) -> &'static str {
-            match self {
-                Kind::Whitespace => "whitespace",
-                Kind::Ident => "identifier",
-                Kind::Int => "integer",
-                Kind::LBrace => "'{'",
-                Kind::RBrace => "'}'",
-                Kind::Semi => "';'",
-                Kind::Eq => "'='",
-                Kind::Unknown => "unknown",
-                Kind::Eof => "end of file",
-            }
-        }
-    }
-
-    fn test_lexer() -> Lexer<Kind> {
-        Lexer::default()
-            .with_rule(Kind::Whitespace, whitespace)
-            .with_rule(Kind::Ident, ident)
-            .with_rule(Kind::Int, digits)
-            .with_rule(Kind::LBrace, literal!("{"))
-            .with_rule(Kind::RBrace, literal!("}"))
-            .with_rule(Kind::Semi, literal!(";"))
-            .with_rule(Kind::Eq, literal!("="))
     }
 
     #[test]
-    fn fn_lex() {
-        let lexer: Lexer<Kind> = test_lexer();
+    fn lex() {
+        let lexer: Lexer<Kind> = Kind::lexer();
         let source: &str = "let x = 42;";
         let tokens: Vec<Token<Kind>> = lexer.lex(source);
 
@@ -137,7 +103,7 @@ mod tests {
             (Kind::Whitespace, " "),
             (Kind::Int, "42"),
             (Kind::Semi, ";"),
-            (Kind::Eof, ""),
+            (Kind::EndOfFile, ""),
         ];
 
         assert_eq!(tokens.len(), expected.len());
@@ -148,18 +114,18 @@ mod tests {
     }
 
     #[test]
-    fn fn_lex_unknown() {
-        let lexer: Lexer<Kind> = test_lexer();
+    fn lex_unknown() {
+        let lexer: Lexer<Kind> = Kind::lexer();
         let source: &str = "x @ y";
         let tokens: Vec<Token<Kind>> = lexer.lex(source);
 
         let expected: &[(Kind, &str)] = &[
             (Kind::Ident, "x"),
             (Kind::Whitespace, " "),
-            (Kind::Unknown, "@"),
+            (Kind::Unrecognized, "@"),
             (Kind::Whitespace, " "),
             (Kind::Ident, "y"),
-            (Kind::Eof, ""),
+            (Kind::EndOfFile, ""),
         ];
 
         assert_eq!(tokens.len(), expected.len());
@@ -170,16 +136,16 @@ mod tests {
     }
 
     #[test]
-    fn fn_lex_empty() {
-        let lexer: Lexer<Kind> = test_lexer();
+    fn lex_empty() {
+        let lexer: Lexer<Kind> = Kind::lexer();
         let tokens: Vec<Token<Kind>> = lexer.lex("");
         assert_eq!(tokens.len(), 1);
-        assert_eq!(tokens[0].kind(), Kind::Eof);
+        assert_eq!(tokens[0].kind(), Kind::EndOfFile);
     }
 
     #[test]
-    fn fn_lex_spans() {
-        let lexer: Lexer<Kind> = test_lexer();
+    fn lex_spans() {
+        let lexer: Lexer<Kind> = Kind::lexer();
         let source: &str = "a 1";
         let tokens: Vec<Token<Kind>> = lexer.lex(source);
 

--- a/src/lexer/macros/lexer.rs
+++ b/src/lexer/macros/lexer.rs
@@ -1,0 +1,65 @@
+/// Defines a token kind enum with a [TokenKind] implementation and a lexer constructor.
+///
+/// Automatically adds `Unrecognized` and `EndOfFile` variants to the enum, implements the
+/// [TokenKind] trait, and generates a `lexer()` method that builds a [Lexer] from the rules.
+///
+/// # Example
+/// ```
+/// use lex::lexer::matchers::{digits, ident, whitespace};
+/// use lex::{keyword, lexer, line_comment, literal};
+///
+/// lexer! {
+///     #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+///     pub enum Kind {
+///         LineComment : line_comment!("//"),
+///         Whitespace : whitespace,
+///         Import : keyword!("import"),
+///         Ident : ident,
+///         Integer : digits,
+///         LBrace : literal!("{"),
+///     }
+/// }
+///
+/// let lexer = Kind::lexer();
+/// let tokens = lexer.lex("import foo {");
+/// assert_eq!(tokens[0].kind(), Kind::Import);
+/// assert_eq!(tokens[2].kind(), Kind::Ident);
+/// assert_eq!(tokens[4].kind(), Kind::LBrace);
+/// assert_eq!(tokens[5].kind(), Kind::EndOfFile);
+/// ```
+#[macro_export]
+macro_rules! lexer {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $($variant:ident : $matcher:expr),* $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        $vis enum $name {
+            $($variant,)*
+            Unrecognized,
+            EndOfFile,
+        }
+
+        impl $crate::lexer::TokenKind for $name {
+            fn unrecognized() -> Self {
+                $name::Unrecognized
+            }
+
+            fn end_of_file() -> Self {
+                $name::EndOfFile
+            }
+        }
+
+        impl $name {
+            //! Lexer
+
+            /// Creates a [Lexer] with rules in the order they were declared.
+            pub fn lexer() -> $crate::lexer::Lexer<$name> {
+                $crate::lexer::Lexer::default()
+                    $(.with_rule($name::$variant, $matcher))*
+            }
+        }
+    };
+}

--- a/src/lexer/macros/mod.rs
+++ b/src/lexer/macros/mod.rs
@@ -1,0 +1,1 @@
+mod lexer;

--- a/src/lexer/matchers/keyword.rs
+++ b/src/lexer/matchers/keyword.rs
@@ -1,0 +1,57 @@
+/// Matches an exact keyword, only if not followed by an identifier character (`[a-zA-Z0-9_]`).
+///
+/// # Example
+/// ```
+/// use lex::keyword;
+///
+/// let matcher: fn(&str) -> Option<usize> = keyword!("message");
+/// assert_eq!(matcher("message {"), Some(7));
+/// assert_eq!(matcher("messageType"), None);
+/// assert_eq!(matcher("message"), Some(7));
+/// ```
+#[macro_export]
+macro_rules! keyword {
+    ($s:literal) => {
+        |source: &str| -> Option<usize> {
+            if source.starts_with($s) {
+                let len: usize = $s.len();
+                if len >= source.len()
+                    || {
+                        let next: u8 = source.as_bytes()[len];
+                        !next.is_ascii_alphanumeric() && next != b'_'
+                    }
+                {
+                    Some(len)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn fn_keyword() {
+        let matcher: fn(&str) -> Option<usize> = keyword!("message");
+
+        let test_cases: &[(&str, Option<usize>)] = &[
+            ("", None),
+            ("msg", None),
+            ("messageType", None),
+            ("message_type", None),
+            ("message123", None),
+            ("message", Some(7)),
+            ("message {", Some(7)),
+            ("message\n", Some(7)),
+        ];
+
+        for (source, expected) in test_cases {
+            assert_eq!(matcher(source), *expected, "source: {:?}", source);
+        }
+    }
+}

--- a/src/lexer/matchers/keyword.rs
+++ b/src/lexer/matchers/keyword.rs
@@ -15,12 +15,10 @@ macro_rules! keyword {
         |source: &str| -> Option<usize> {
             if source.starts_with($s) {
                 let len: usize = $s.len();
-                if len >= source.len()
-                    || {
-                        let next: u8 = source.as_bytes()[len];
-                        !next.is_ascii_alphanumeric() && next != b'_'
-                    }
-                {
+                if len >= source.len() || {
+                    let next: u8 = source.as_bytes()[len];
+                    !next.is_ascii_alphanumeric() && next != b'_'
+                } {
                     Some(len)
                 } else {
                     None

--- a/src/lexer/matchers/mod.rs
+++ b/src/lexer/matchers/mod.rs
@@ -4,7 +4,7 @@ pub use whitespace::*;
 
 mod digits;
 mod ident;
-mod whitespace;
-
+mod keyword;
 mod line_comment;
 mod literal;
+mod whitespace;

--- a/src/lexer/matchers/whitespace.rs
+++ b/src/lexer/matchers/whitespace.rs
@@ -1,4 +1,5 @@
-/// Matches one or more ASCII whitespace bytes: spaces, tabs, newlines, and carriage returns.
+/// Matches one or more ASCII whitespace bytes: spaces, tabs, newlines, carriage returns, and form
+/// feeds.
 pub fn whitespace(source: &str) -> Option<usize> {
     let bytes: &[u8] = source.as_bytes();
     let mut len: usize = 0;

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -10,4 +10,5 @@ mod span;
 mod token;
 mod token_kind;
 
+mod macros;
 pub mod matchers;

--- a/src/lexer/rule.rs
+++ b/src/lexer/rule.rs
@@ -1,5 +1,5 @@
 /// A lexer rule. Maps a matcher function to a kind of lexical token.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Rule<K> {
     kind: K,
     matcher: fn(&str) -> Option<usize>,
@@ -18,7 +18,7 @@ impl<K: Copy> Rule<K> {
     //! Properties
 
     /// Gets the token kind.
-    pub(in crate::lexer) fn kind(&self) -> K {
+    pub(in crate::lexer) fn kind(self) -> K {
         self.kind
     }
 }

--- a/src/lexer/span.rs
+++ b/src/lexer/span.rs
@@ -1,8 +1,10 @@
+use std::fmt::{Display, Formatter};
+
 /// A byte span in source text.
 ///
 /// The `offset` and `offset + len` must lie on valid UTF-8 char boundaries in the source text the
 /// span was derived from. The `text` function will panic otherwise.
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Span {
     offset: u32,
     len: u32,
@@ -32,9 +34,36 @@ impl Span {
         self.len
     }
 
+    /// Gets the end byte offset. (`offset + len`)
+    pub const fn end(self) -> u32 {
+        self.offset + self.len
+    }
+
     /// Checks if the span is empty.
     pub const fn is_empty(self) -> bool {
         self.len == 0
+    }
+}
+
+impl Span {
+    //! Line & Column
+
+    /// Gets the 0-indexed line and column for the start of the span.
+    pub fn line_column(self, source: &str) -> (usize, usize) {
+        debug_assert!(source.is_char_boundary(self.offset as usize));
+
+        let offset: usize = self.offset as usize;
+        let mut line: usize = 0;
+        let mut col: usize = 0;
+        for byte in &source.as_bytes()[..offset] {
+            if *byte == b'\n' {
+                line += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+        (line, col)
     }
 }
 
@@ -43,10 +72,44 @@ impl Span {
 
     /// Gets the text from the `source`.
     pub fn text(self, source: &str) -> &str {
-        debug_assert!(source.len() <= u32::MAX as usize);
+        debug_assert!(source.is_char_boundary(self.offset as usize));
+        debug_assert!(source.is_char_boundary(self.end() as usize));
 
         let start: usize = self.offset as usize;
         let end: usize = start + self.len as usize;
         &source[start..end]
+    }
+}
+
+impl Display for Span {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "span[offset={}, len={}]", self.offset, self.len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text() {
+        let source: &str = "hello world";
+        assert_eq!(Span::new(0, 5).text(source), "hello");
+        assert_eq!(Span::new(6, 5).text(source), "world");
+        assert_eq!(Span::new(0, 0).text(source), "");
+        assert_eq!(Span::new(0, 11).text(source), "hello world");
+    }
+
+    #[test]
+    fn line_column() {
+        let source: &str = "ab\ncd\nef";
+        assert_eq!(Span::new(0, 1).line_column(source), (0, 0));
+        assert_eq!(Span::new(1, 1).line_column(source), (0, 1));
+        assert_eq!(Span::new(3, 1).line_column(source), (1, 0));
+        assert_eq!(Span::new(4, 1).line_column(source), (1, 1));
+        assert_eq!(Span::new(6, 1).line_column(source), (2, 0));
+        assert_eq!(Span::new(7, 1).line_column(source), (2, 1));
+        assert_eq!(Span::new(0, 0).line_column(""), (0, 0));
+        assert_eq!(Span::new(0, 1).line_column("a"), (0, 0));
     }
 }

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -1,7 +1,8 @@
 use crate::lexer::Span;
+use std::fmt::{Display, Formatter};
 
 /// A lexical token.
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Token<K> {
     kind: K,
     span: Span,
@@ -32,5 +33,11 @@ impl<K: Copy> Token<K> {
     /// Gets the token text from the `source`.
     pub fn text(self, source: &str) -> &str {
         self.span.text(source)
+    }
+}
+
+impl<K: Display> Display for Token<K> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "token[{}, {}]", self.kind, self.span)
     }
 }

--- a/src/lexer/token_kind.rs
+++ b/src/lexer/token_kind.rs
@@ -1,11 +1,15 @@
+use std::fmt::Debug;
+
 /// A kind of lexical token.
-pub trait TokenKind {
-    /// Gets the kind of token to be used when there are no matching rules.
-    fn unknown() -> Self;
+pub trait TokenKind: Debug {
+    /// Gets the kind of lexical token for unrecognized tokens.
+    fn unrecognized() -> Self;
 
     /// Gets the end-of-file token kind.
-    fn eof() -> Self;
+    fn end_of_file() -> Self;
 
-    /// Gets the display label for this token kind. (e.g. `"identifier"`, `"'{'"`, `"end of file"`)
-    fn label(&self) -> &'static str;
+    /// Gets the display label for this token kind. (e.g. `"identifier"`, `"'{'"`, `"end-of-file"`)
+    fn label(&self) -> String {
+        format!("{:?}", self)
+    }
 }

--- a/src/parser/comment_config.rs
+++ b/src/parser/comment_config.rs
@@ -1,0 +1,6 @@
+/// A line comment configuration.
+#[derive(Copy, Clone)]
+pub(in crate::parser) struct CommentConfig<K> {
+    pub(in crate::parser) kind: K,
+    pub(in crate::parser) delimiter_len: usize,
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,5 +3,6 @@ pub use parse_error::*;
 pub use parser::*;
 
 mod checkpoint;
+mod comment_config;
 mod parse_error;
 mod parser;

--- a/src/parser/parse_error.rs
+++ b/src/parser/parse_error.rs
@@ -1,7 +1,9 @@
+use std::fmt::{Display, Formatter};
+
 use crate::lexer::Span;
 
 /// A parse error.
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ParseError {
     span: Span,
     message: String,
@@ -32,3 +34,11 @@ impl ParseError {
         &self.message
     }
 }
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "byte {}: {}", self.span.offset(), self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,12 +1,6 @@
 use crate::lexer::{Span, Token, TokenKind};
+use crate::parser::comment_config::CommentConfig;
 use crate::parser::{Checkpoint, ParseError};
-
-/// A line comment configuration.
-#[derive(Copy, Clone)]
-struct CommentConfig<K> {
-    kind: K,
-    delimiter_len: usize,
-}
 
 /// A parser.
 pub struct Parser<K> {
@@ -23,7 +17,7 @@ impl<K: Copy + PartialEq + TokenKind> Parser<K> {
 
     /// Creates a new parser.
     pub fn new(source: String, tokens: Vec<Token<K>>) -> Self {
-        debug_assert!(!tokens.is_empty() && tokens.last().unwrap().kind() == K::eof());
+        debug_assert!(!tokens.is_empty() && tokens.last().unwrap().kind() == K::end_of_file());
 
         Self {
             source,
@@ -46,6 +40,7 @@ impl<K: Copy + PartialEq> Parser<K> {
     }
 
     /// Adds a token kind to skip during parsing. (builder pattern)
+    #[must_use]
     pub fn with_skip(mut self, kind: K) -> Self {
         self.add_skip(kind);
         self
@@ -63,6 +58,7 @@ impl<K: Copy + PartialEq> Parser<K> {
     //! Comments
 
     /// Configures line comment extraction.
+    #[must_use]
     pub fn with_line_comment(mut self, kind: K, delimiter: &str) -> Self {
         self.comment = Some(CommentConfig {
             kind,
@@ -127,10 +123,12 @@ impl<K: Copy + PartialEq> Parser<K> {
         self.tokens[self.pos]
     }
 
-    /// Peeks at the `n`th non-skipped token after the current position. (0-indexed)
+    /// Peeks at the `n`th non-skipped token from the current position. (0-indexed)
+    ///
+    /// `lookahead(0)` is equivalent to `peek()`.
     pub fn lookahead(&self, n: usize) -> Option<Token<K>> {
         let mut remaining: usize = n;
-        let mut i: usize = self.pos + 1;
+        let mut i: usize = self.pos;
         while i < self.tokens.len() {
             if !self.skip.contains(&self.tokens[i].kind()) {
                 if remaining == 0 {
@@ -157,7 +155,7 @@ impl<K: Copy + PartialEq + TokenKind> Parser<K> {
     /// Returns `None` if at EOF.
     pub fn advance(&mut self) -> Option<Token<K>> {
         let pos: usize = self.pos;
-        if self.tokens[pos].kind() == K::eof() {
+        if self.tokens[pos].kind() == K::end_of_file() {
             None
         } else {
             self.pos += 1;
@@ -168,13 +166,24 @@ impl<K: Copy + PartialEq + TokenKind> Parser<K> {
 
     /// Advances if the current token matches the `kind`.
     ///
+    /// Returns `None` without recording an error if it does not match.
+    pub fn accept(&mut self, kind: K) -> Option<Token<K>> {
+        if self.check(kind) {
+            self.advance()
+        } else {
+            None
+        }
+    }
+
+    /// Advances if the current token matches the `kind`.
+    ///
     /// Returns `None` and records an auto-generated error if it does not match.
     pub fn expect(&mut self, kind: K) -> Option<Token<K>> {
         if self.check(kind) {
             self.advance()
         } else {
-            let found: &'static str = self.peek().kind().label();
-            let expected: &'static str = kind.label();
+            let found: String = self.peek().kind().label();
+            let expected: String = kind.label();
             let message: String = format!("expected {expected}, found {found}");
             self.error(message);
             None
@@ -195,7 +204,7 @@ impl<K: Copy + PartialEq + TokenKind> Parser<K> {
 
     /// Advances until the current token matches the `kind` or EOF is reached.
     pub fn skip_until(&mut self, kind: K) {
-        while !self.check(kind) && !self.check(K::eof()) {
+        while !self.check(kind) && !self.check(K::end_of_file()) {
             self.advance();
         }
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -139,10 +139,7 @@ fn fn_parse_message_missing_brace() {
 
     assert!(message.is_none());
     assert_eq!(parser.errors().len(), 1);
-    assert_eq!(
-        parser.errors()[0].message(),
-        "expected LBrace, found Ident"
-    );
+    assert_eq!(parser.errors()[0].message(), "expected LBrace, found Ident");
 }
 
 #[test]

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,44 +1,19 @@
 use lex::lexer::matchers::{digits, ident, whitespace};
-use lex::lexer::{Lexer, Token, TokenKind};
+use lex::lexer::{Lexer, Token};
 use lex::parser::Parser;
-use lex::{line_comment, literal};
+use lex::{lexer, line_comment, literal};
 
-#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-enum Kind {
-    Whitespace,
-    LineComment,
-    Ident,
-    Int,
-    LBrace,
-    RBrace,
-    Eq,
-    Semi,
-    Unknown,
-    Eof,
-}
-
-impl TokenKind for Kind {
-    fn unknown() -> Self {
-        Kind::Unknown
-    }
-
-    fn eof() -> Self {
-        Kind::Eof
-    }
-
-    fn label(&self) -> &'static str {
-        match self {
-            Kind::Whitespace => "whitespace",
-            Kind::LineComment => "line comment",
-            Kind::Ident => "identifier",
-            Kind::Int => "integer",
-            Kind::LBrace => "'{'",
-            Kind::RBrace => "'}'",
-            Kind::Eq => "'='",
-            Kind::Semi => "';'",
-            Kind::Unknown => "unknown",
-            Kind::Eof => "end of file",
-        }
+lexer! {
+    #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    enum Kind {
+        Whitespace: whitespace,
+        LineComment: line_comment!("//"),
+        Ident: ident,
+        Int: digits,
+        LBrace: literal!("{"),
+        RBrace: literal!("}"),
+        Eq: literal!("="),
+        Semi: literal!(";"),
     }
 }
 
@@ -55,18 +30,6 @@ struct Field {
     number: String,
 }
 
-fn proto_lexer() -> Lexer<Kind> {
-    Lexer::default()
-        .with_rule(Kind::Whitespace, whitespace)
-        .with_rule(Kind::LineComment, line_comment!("//"))
-        .with_rule(Kind::Ident, ident)
-        .with_rule(Kind::Int, digits)
-        .with_rule(Kind::LBrace, literal!("{"))
-        .with_rule(Kind::RBrace, literal!("}"))
-        .with_rule(Kind::Eq, literal!("="))
-        .with_rule(Kind::Semi, literal!(";"))
-}
-
 fn parse_message(p: &mut Parser<Kind>) -> Option<Message> {
     let keyword: Token<Kind> = p.expect(Kind::Ident)?;
     if p.text(keyword.span()) != "message" {
@@ -80,7 +43,7 @@ fn parse_message(p: &mut Parser<Kind>) -> Option<Message> {
     p.expect(Kind::LBrace)?;
 
     let mut fields: Vec<Field> = Vec::default();
-    while !p.check(Kind::RBrace) && !p.check(Kind::Eof) {
+    while !p.check(Kind::RBrace) && !p.check(Kind::EndOfFile) {
         match parse_field(p) {
             Some(field) => fields.push(field),
             None => {
@@ -119,7 +82,7 @@ fn parse_field(p: &mut Parser<Kind>) -> Option<Field> {
 #[test]
 fn fn_parse_message() {
     let source: String = "message Foo { string name = 1; int32 id = 2; }".to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens).with_skip(Kind::Whitespace);
 
@@ -149,7 +112,7 @@ fn fn_parse_message() {
 #[test]
 fn fn_parse_message_empty() {
     let source: String = "message Empty {}".to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens).with_skip(Kind::Whitespace);
 
@@ -168,7 +131,7 @@ fn fn_parse_message_empty() {
 #[test]
 fn fn_parse_message_missing_brace() {
     let source: String = "message Foo string name = 1; }".to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens).with_skip(Kind::Whitespace);
 
@@ -178,14 +141,14 @@ fn fn_parse_message_missing_brace() {
     assert_eq!(parser.errors().len(), 1);
     assert_eq!(
         parser.errors()[0].message(),
-        "expected '{', found identifier"
+        "expected LBrace, found Ident"
     );
 }
 
 #[test]
 fn fn_parse_message_recovery() {
     let source: String = "message Foo { string = 1; int32 id = 2; }".to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens).with_skip(Kind::Whitespace);
 
@@ -215,7 +178,7 @@ fn fn_parse_message_multiline() {
     int32 age = 3;
 }"#
     .to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens).with_skip(Kind::Whitespace);
 
@@ -264,7 +227,7 @@ fn parse_commented_message(p: &mut Parser<Kind>) -> Option<CommentedMessage> {
     p.expect(Kind::LBrace)?;
 
     let mut fields: Vec<CommentedField> = Vec::default();
-    while !p.check(Kind::RBrace) && !p.check(Kind::Eof) {
+    while !p.check(Kind::RBrace) && !p.check(Kind::EndOfFile) {
         match parse_commented_field(p) {
             Some(field) => fields.push(field),
             None => {
@@ -322,7 +285,7 @@ message Person {
     int32 age = 2;
 }"#
     .to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens)
         .with_skip(Kind::Whitespace)
@@ -351,7 +314,7 @@ message Person {
 #[test]
 fn fn_parse_message_no_comments() {
     let source: String = "message Foo { string name = 1; }".to_string();
-    let lexer: Lexer<Kind> = proto_lexer();
+    let lexer: Lexer<Kind> = Kind::lexer();
     let tokens: Vec<Token<Kind>> = lexer.lex(&source);
     let mut parser: Parser<Kind> = Parser::new(source, tokens)
         .with_skip(Kind::Whitespace)


### PR DESCRIPTION
 Lexer

  - Added lexer! declarative macro that defines a token kind enum, implements TokenKind, and generates a lexer constructor in a single declaration
  - Added keyword! matcher macro for word-boundary-aware keyword matching
  - Renamed TokenKind methods: unknown() → unrecognized(), eof() → end_of_file()
  - label() now has a default implementation using Debug formatting and returns String
  - TokenKind requires Debug as a supertrait
  - Added Debug derive to Lexer and Rule
  - Rule::kind() now takes self instead of &self
  - Lexer::with_rule() is now #[must_use]

  Parser

  - Added Parser::accept() for non-error-recording optional token consumption
  - Parser::lookahead(0) now equals peek() (starts at current position)
  - Parser::with_skip() and with_line_comment() are now #[must_use]
  - Extracted CommentConfig to its own file

  Span

  - Added Span::end() convenience method
  - Added Span::line_column() for 0-indexed line/column calculation
  - Added Display impl for Span
  - Added char boundary debug asserts on text() and line_column()

  ParseError

  - Added Display and std::error::Error implementations

  Other

  - Added Display impl for Token
  - Fixed whitespace doc to mention form feed
  - Standardized derive ordering across all types
  - Updated README with lexer! macro example